### PR TITLE
Update facet_grid calls with ggplot in stats script

### DIFF
--- a/envs/marti_env.yml
+++ b/envs/marti_env.yml
@@ -13,5 +13,9 @@ dependencies:
   - clangxx_osx-64=16 #[osx]
   - openmp
   - htslib
-  - python=3.8
+  - python=3.10
+  - matplotlib
+  - plotnine
+  - tqdm
+  - pysam
   - pip

--- a/scripts/classification_stats.py
+++ b/scripts/classification_stats.py
@@ -221,7 +221,7 @@ class MartiStats:
         plots = []
         for experiment in self.experiments:
         	plots.append((ggplot(df_adapter[df_adapter['experiment']==experiment])
-                + facet_grid(facets="class_profile~adapter", scales="free")
+                + facet_grid(rows="class_profile", cols="adapter", scales="free")
                 + geom_bar(aes(x='lev', y='..prop..'), fill='darkseagreen') 
                 + self.get_theme()
                 + ggtitle("Adapter Levenshtein distance" + ": experiment " + experiment)
@@ -231,7 +231,7 @@ class MartiStats:
                 ))
         for experiment in self.experiments:
         	plots.append((ggplot(df_poly[df_poly['experiment']==experiment])
-                + facet_grid(facets="class_profile~adapter", scales="free")
+                + facet_grid(rows="class_profile", cols="adapter", scales="free")
                 + geom_bar(aes(x='lev', y='..prop..'), fill='darkseagreen') 
                 + self.get_theme()
                 + ggtitle("polyA/polyT Levenshtein distance" + ": experiment " + experiment)
@@ -258,7 +258,7 @@ class MartiStats:
         plots = []
         for experiment in self.experiments:
         	plots.append((ggplot(df_start[df_start['experiment']==experiment])
-                + facet_grid(facets="class_profile~adapter", scales="free")
+                + facet_grid(rows="class_profile", cols="adapter", scales="free")
                 + geom_bar(aes(x='offset', y='..count..'), fill='cadetblue') 
                 + self.get_theme()
                 + scale_y_log10()
@@ -269,7 +269,7 @@ class MartiStats:
                 ))
         for experiment in self.experiments:
         	plots.append((ggplot(df_end[df_end['experiment']==experiment])
-                + facet_grid(facets="class_profile~adapter", scales="free")
+                + facet_grid(rows="class_profile", cols="adapter", scales="free")
                 + geom_bar(aes(x='offset', y='..count..'), fill='cadetblue') 
                 + self.get_theme()
                 + scale_y_log10()


### PR DESCRIPTION
May only be relevant/good for newer versions of Python.

Update facet_grid calls with ggplot since the 'facets' argument is deprecated and requires using 'rows' and 'cols' instead. Not sure when it became deprecated because it used to run just fine. https://ggplot2.tidyverse.org/reference/facet_grid.html